### PR TITLE
Spark 1.5 / EMR 4.1.0

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,5 +3,31 @@
 sudo yum-config-manager --enable epel
 sudo yum -y install geos proj proj-nad proj-epsg
 sudo ln -s /usr/lib64/libproj.so.0 /usr/lib64/libproj.so
-curl http://oam-server-tiler.s3.amazonaws.com/emr/gdal-1.11.2-amz1.tar.gz | sudo tar zxf - -C /usr/local
+aws s3 cp s3://oam-server-tiler/emr/gdal-1.11.2-amz1.tar.gz - | sudo tar zxf - -C /usr/local
 sudo GDAL_CONFIG=/usr/local/bin/gdal-config pip-2.7 install boto3 rasterio mercantile psutil
+
+sudo yum -y install inotify-tools
+
+cat <<EOF > /tmp/update-pyspark
+#!/bin/sh
+
+# create the target directory so we can watch it
+sudo mkdir -p /usr/lib/spark/python/lib
+
+# download the replacement zip
+aws s3 cp s3://oam-server-tiler/emr/pyspark-1.5.1.zip /tmp/pyspark-1.5.1.zip
+
+# wait for yum to install spark-core
+inotifywait -e create /usr/lib/spark/python/lib
+
+# allow some time for writing to complete
+sleep 5
+
+# replace pyspark.zip
+sudo mv /tmp/pyspark-1.5.1.zip /usr/lib/spark/python/lib/pyspark.zip
+EOF
+
+chmod +x /tmp/update-pyspark
+
+# background pyspark updating so that bootstrapping can complete
+nohup /tmp/update-pyspark &

--- a/chunk/chunk.py
+++ b/chunk/chunk.py
@@ -15,7 +15,7 @@ import rasterio
 from rasterio import transform
 from rasterio import crs
 from rasterio import warp
-from rasterio.warp import (reproject, RESAMPLING, calculate_default_transform)
+from rasterio.warp import (reproject, calculate_default_transform)
 from rasterio._io import virtual_file_to_buffer
 
 from affine import Affine
@@ -282,7 +282,8 @@ def process_chunk_task(task):
                     destination=warped[bidx - 1],
                     dst_transform=meta["transform"],
                     dst_crs=meta["crs"],
-                    resampling=RESAMPLING.bilinear
+                    # NOTE: not using rasterio.warp.RESAMPLING because it breaks pyspark-1.5.x
+                    resampling=1, # bilinear
                 )
 
             # check for chunks containing only zero values

--- a/launch-cluster.sh
+++ b/launch-cluster.sh
@@ -4,18 +4,20 @@ MASTER_INSTANCE=m3.xlarge
 MASTER_PRICE=0.15
 
 WORKER_INSTANCE=m3.xlarge
-WORKER_PRICE=0.15
-WORKER_COUNT=10
+WORKER_COUNT=2
+SPOT_WORKER_PRICE=0.15
+SPOT_WORKER_COUNT=8
 
 aws emr create-cluster \
   --name "OAM Tiler" \
   --log-uri s3://oam-server-tiler/emr/logs/ \
-  --release-label emr-4.0.0 \
+  --release-label emr-4.1.0 \
   --use-default-roles \
-  --ec2-attributes KeyName=oam-emanuele \
+  --ec2-attributes KeyName=oam-mojodna \
   --applications Name=Spark \
   --instance-groups \
     Name=Master,InstanceCount=1,InstanceGroupType=MASTER,InstanceType=$MASTER_INSTANCE \
-    Name=Workers,InstanceCount=$WORKER_COUNT,BidPrice=$WORKER_PRICE,InstanceGroupType=CORE,InstanceType=$WORKER_INSTANCE \
+    Name=ReservedWorkers,InstanceCount=$WORKER_COUNT,InstanceGroupType=CORE,InstanceType=$WORKER_INSTANCE \
+    Name=SpotWorkers,InstanceCount=$SPOT_WORKER_COUNT,BidPrice=$SPOT_WORKER_PRICE,InstanceGroupType=CORE,InstanceType=$WORKER_INSTANCE \
   --bootstrap-action Path=s3://oam-server-tiler/emr/bootstrap.sh \
   --configurations s3://oam-server-tiler/emr/configurations.js


### PR DESCRIPTION
Pyspark 1.5.1 includes an important fix for serialization of named tuples, so that gets pulled as part of the bootstrap process (though it needs to replace a ZIP that's installed as part of spark-core (yum) after the bootstrap actions complete--observe the nasty use of `inotifywait` in a backgrounded sub-task).

EMR-4.1.0 supports variably-sized clusters and will begin processing as soon as part of the cluster is available, allowing us to make better use of reserved + spot instances.
