### PR TITLE
Removed initial rasterio workspace copy in favor of GDAL command line.

### DIFF
--- a/add-step1.sh
+++ b/add-step1.sh
@@ -1,12 +1,14 @@
-CLUSTER_ID=j-3HD42KV231ZH5
+CLUSTER_ID=j-15976XB73IB3I
 
 DRIVER_MEMORY=2g
 NUM_EXECUTORS=40
 EXECUTOR_MEMORY=2304m
 EXECUTOR_CORES=1
 
-REQUEST_URI=s3://workspace-oam-hotosm-org/test-req-partial.json
-WORKSPACE_URI=s3://workspace-oam-hotosm-org/emr-test-job-partial
+REQUEST_URI=s3://oam-server-tiler/requests/ac548563-e1c4-4e11-8e8a-661167beed18.json
+WORKSPACE_URI=s3://oam-server-tiler/workspace/ac548563-e1c4-4e11-8e8a-661167beed18
+# REQUEST_URI=s3://oam-server-tiler/requests/b79c9412-d60e-40bd-a88f-b3bfd1840ae3.json
+# WORKSPACE_URI=s3://oam-server-tiler/workspace/b79c9412-d60e-40bd-a88f-b3bfd1840ae3
 
 aws emr add-steps \
   --cluster-id $CLUSTER_ID \

--- a/add-step2.sh
+++ b/add-step2.sh
@@ -1,12 +1,15 @@
-CLUSTER_ID=j-RRHMKKWUYLTT
+CLUSTER_ID=j-15976XB73IB3I
 
 DRIVER_MEMORY=2g
 NUM_EXECUTORS=40
 EXECUTOR_MEMORY=2304m
 EXECUTOR_CORES=1
 
-REQUEST_URI=s3://workspace-oam-hotosm-org/test-req-partial.json
-WORKSPACE_URI=s3://workspace-oam-hotosm-org/emr-test-job-partial
+REQUEST_URI=s3://oam-server-tiler/requests/ac548563-e1c4-4e11-8e8a-661167beed18.json
+WORKSPACE_URI=s3://oam-server-tiler/workspace/ac548563-e1c4-4e11-8e8a-661167beed18
+
+# REQUEST_URI=s3://workspace-oam-hotosm-org/test-req-partial.json
+# WORKSPACE_URI=s3://workspace-oam-hotosm-org/emr-test-job-partial
 
 
 aws emr add-steps \

--- a/add-steps.sh
+++ b/add-steps.sh
@@ -1,12 +1,12 @@
-CLUSTER_ID=j-2R48YBD6AJTWQ
+CLUSTER_ID=j-38B7UZSX1K8Z3
 
 DRIVER_MEMORY=2g
 NUM_EXECUTORS=40
 EXECUTOR_MEMORY=2304m
 EXECUTOR_CORES=1
 
-REQUEST_URI=s3://workspace-oam-hotosm-org/test-req-partial.json
-WORKSPACE_URI=s3://workspace-oam-hotosm-org/emr-test-job-partial
+REQUEST_URI=s3://oam-server-tiler/testfiles/test-req-partial.json
+WORKSPACE_URI=s3://oam-server-tiler/workspace/emr-test-job-partial
 
 aws emr add-steps \
   --cluster-id $CLUSTER_ID \

--- a/add-test-step.sh
+++ b/add-test-step.sh
@@ -1,0 +1,16 @@
+CLUSTER_ID=j-34T4JOTY45LCR
+
+DRIVER_MEMORY=2g
+NUM_EXECUTORS=40
+EXECUTOR_MEMORY=2304m
+EXECUTOR_CORES=1
+
+REQUEST_URI=s3://oam-server-tiler/requests/8e662d19-07cd-4a0d-a7a1-cec872f13f28.json
+WORKSPACE_URI=s3://oam-server-tiler/workspace/8e662d19-07cd-4a0d-a7a1-cec872f13f28
+# REQUEST_URI=s3://oam-server-tiler/requests/b79c9412-d60e-40bd-a88f-b3bfd1840ae3.json
+# WORKSPACE_URI=s3://oam-server-tiler/workspace/b79c9412-d60e-40bd-a88f-b3bfd1840ae3
+
+aws emr add-steps \
+  --cluster-id $CLUSTER_ID \
+  --steps \
+    Name=CHUNK,ActionOnFailure=CONTINUE,Type=Spark,Args=[--deploy-mode,cluster,--driver-memory,$DRIVER_MEMORY,--num-executors,$NUM_EXECUTORS,--executor-memory,$EXECUTOR_MEMORY,--executor-cores,$EXECUTOR_CORES,s3://oam-server-tiler/test.py]

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,33 +1,10 @@
 #!/bin/sh -e
 
 sudo yum-config-manager --enable epel
-sudo yum -y install geos proj proj-nad proj-epsg
+sudo yum -y install geos proj proj-nad proj-epsg libcurl-devel.x86_64
 sudo ln -s /usr/lib64/libproj.so.0 /usr/lib64/libproj.so
-aws s3 cp s3://oam-server-tiler/emr/gdal-1.11.2-amz1.tar.gz - | sudo tar zxf - -C /usr/local
-sudo GDAL_CONFIG=/usr/local/bin/gdal-config pip-2.7 install boto3 rasterio mercantile psutil
+aws s3 cp s3://oam-server-tiler/emr/gdal-1.11.2-amz2.tar.gz - | sudo tar zxf - -C /usr/local
+aws s3 cp s3://oam-server-tiler/emr/gdal-1.11.2-amz2-py.tar.gz - | sudo tar zxf - -C /usr/local/lib64/python2.6/site-packages
+sudo GDAL_CONFIG=/usr/local/bin/gdal-config pip-2.7 install boto3 rasterio==0.29.0 mercantile psutil
 
 sudo yum -y install inotify-tools
-
-cat <<EOF > /tmp/update-pyspark
-#!/bin/sh
-
-# create the target directory so we can watch it
-sudo mkdir -p /usr/lib/spark/python/lib
-
-# download the replacement zip
-aws s3 cp s3://oam-server-tiler/emr/pyspark-1.5.1.zip /tmp/pyspark-1.5.1.zip
-
-# wait for yum to install spark-core
-inotifywait -e create /usr/lib/spark/python/lib
-
-# allow some time for writing to complete
-sleep 5
-
-# replace pyspark.zip
-sudo mv /tmp/pyspark-1.5.1.zip /usr/lib/spark/python/lib/pyspark.zip
-EOF
-
-chmod +x /tmp/update-pyspark
-
-# background pyspark updating so that bootstrapping can complete
-nohup /tmp/update-pyspark &

--- a/chunk/chunk.py
+++ b/chunk/chunk.py
@@ -10,7 +10,6 @@ from collections import namedtuple
 from subprocess import call
 
 import boto3
-from boto3.s3.transfer import S3Transfer
 import mercantile
 import numpy
 import rasterio
@@ -61,7 +60,7 @@ def get_local_copy(uri, local_dir):
     parsed = urlparse(uri)
     local_path = tempfile.mktemp(dir=local_dir)
     if parsed.scheme == "s3":
-        cmd = ["aws", "s3", "cp",uri, local_path]
+        cmd = ["aws", "s3", "cp", uri, local_path]
     elif parsed.scheme == "http":
         cmd = ["wget", "-O", local_path, uri]
     else:
@@ -116,7 +115,7 @@ def vsi_curlify(uri):
     else:
         if parsed.scheme == "s3":
             result_uri = "/vsicurl/http://%s.s3.amazonaws.com%s" % (parsed.netloc, parsed.path)
-        elif parsed.scheme == "http":
+        elif parsed.scheme.startswith("http"):
             result_uri = "/vsicurl/%s" % uri
         else:
             raise Exception("Unsupported scheme: %s" % parsed.schem)

--- a/launch-cluster.sh
+++ b/launch-cluster.sh
@@ -11,13 +11,13 @@ SPOT_WORKER_COUNT=8
 aws emr create-cluster \
   --name "OAM Tiler" \
   --log-uri s3://oam-server-tiler/emr/logs/ \
-  --release-label emr-4.1.0 \
+  --release-label emr-4.2.0 \
   --use-default-roles \
-  --ec2-attributes KeyName=oam-mojodna \
+  --ec2-attributes KeyName=oam-emanuele \
   --applications Name=Spark \
   --instance-groups \
     Name=Master,InstanceCount=1,InstanceGroupType=MASTER,InstanceType=$MASTER_INSTANCE \
     Name=ReservedWorkers,InstanceCount=$WORKER_COUNT,InstanceGroupType=CORE,InstanceType=$WORKER_INSTANCE \
-    Name=SpotWorkers,InstanceCount=$SPOT_WORKER_COUNT,BidPrice=$SPOT_WORKER_PRICE,InstanceGroupType=CORE,InstanceType=$WORKER_INSTANCE \
+    Name=SpotWorkers,InstanceCount=$SPOT_WORKER_COUNT,BidPrice=$SPOT_WORKER_PRICE,InstanceGroupType=TASK,InstanceType=$WORKER_INSTANCE \
   --bootstrap-action Path=s3://oam-server-tiler/emr/bootstrap.sh \
-  --configurations s3://oam-server-tiler/emr/configurations.js
+  --configurations https://oam-server-tiler.s3.amazonaws.com/emr/configurations.json

--- a/mosaic/build.sbt
+++ b/mosaic/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.2.1",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.9.34",
   "com.amazonaws" % "aws-java-sdk-sqs" % "1.9.34",
-  "com.azavea.geotrellis" %%  "geotrellis-testkit" % "0.10.0-SNAPSHOT" % "test",
+  "com.azavea.geotrellis" %%  "geotrellis-testkit" % Version.geotrellis % "test",
   "org.scalatest" %%  "scalatest" % "2.2.0" % "test"
 )
 

--- a/mosaic/project/Version.scala
+++ b/mosaic/project/Version.scala
@@ -3,5 +3,5 @@ object Version {
   val scala       = "2.10.5"
   val spark       = "1.4.1"
 
-  val geotrellis  = "0.10.0-337165e"
+  val geotrellis  = "0.10.0-5ff9688"
 }

--- a/mosaic/src/main/scala/org/hotosm/oam/JobRequest.scala
+++ b/mosaic/src/main/scala/org/hotosm/oam/JobRequest.scala
@@ -13,7 +13,10 @@ case class JobRequest(id: String, target: String, tileSize: Int, inputImageDefin
         val reader =
           new java.net.URI(imagesFolder).getScheme match {
             case "s3" => new S3TileServiceReader[MultiBandTile](imagesFolder)
-            case null => new FileTileServiceReader[MultiBandTile](imagesFolder)
+            case null => 
+              if(!new java.io.File(imagesFolder).exists)
+                sys.error(s"Directory $imagesFolder does not exist.")
+              new FileTileServiceReader[MultiBandTile](imagesFolder)
           }
 
         val rdd = reader.read(zoom)
@@ -37,6 +40,7 @@ case class JobRequest(id: String, target: String, tileSize: Int, inputImageDefin
               .flatMap { case (key, image) =>
                 InputImageRDD.split(key, image, tilesAcross)
               }
+
           InputImageRDD(priority, adjustedZoom, adjustedGridBounds, images)
         }
       }

--- a/mosaic/src/main/scala/org/hotosm/oam/TileCounts.scala
+++ b/mosaic/src/main/scala/org/hotosm/oam/TileCounts.scala
@@ -12,6 +12,7 @@ trait TileCounts {
 
 object TileCounts {
   def apply(zoomsToGridBounds: Seq[(Int, GridBounds)]): TileCounts = {
+    val imageCount = zoomsToGridBounds.size
     val zoomMap =
       zoomsToGridBounds
         .foldLeft(Map[Int, Seq[GridBounds]]()) { (acc, tup) =>
@@ -52,8 +53,8 @@ object TileCounts {
 
           (
             distinctBounds,
-            mergedCounts + ((zoom, distinctBounds.map(_.size).sum)),
-            unmergedCounts + ((zoom, bounds.map(_.size).sum))
+            mergedCounts + ((zoom, distinctBounds.map(_.size).sum * imageCount)),
+            unmergedCounts + ((zoom, bounds.map(_.size).sum * imageCount))
           )
         }
 

--- a/mosaic/src/main/scala/org/hotosm/oam/ZoomUp.scala
+++ b/mosaic/src/main/scala/org/hotosm/oam/ZoomUp.scala
@@ -78,9 +78,6 @@ object ZoomUp {
 
           for((thisKey, thisImage) <- seqTiles) {
             val thisExtent = TileMath.getExtent(thisZoom, thisKey.col, thisKey.row)
-            if(thisExtent.width  < 0.001) {
-              sys.error(s"THIS ONE $thisExtent $thisZoom $thisKey")
-            }
 
             ZoomUp.mergeImage(nextImage, thisImage.image, nextExtent, thisExtent)
             nextOrder = nextOrder.merge(nextExtent, thisExtent, thisImage.order)

--- a/run-emr.sh
+++ b/run-emr.sh
@@ -15,10 +15,10 @@ NUM_EXECUTORS=40
 EXECUTOR_MEMORY=2304m
 EXECUTOR_CORES=1
 
-JOB_ID=20151012-1
+JOB_ID=rob-test-jan-2016
 
-REQUEST_URI=s3://workspace-oam-hotosm-org/test-req-partial-${JOB_ID}.json
-WORKSPACE_URI=s3://workspace-oam-hotosm-org/emr-test-job-partial-${JOB_ID}
+REQUEST_URI=s3://oam-server-tiler/test-files/test-req-partial-${JOB_ID}.json
+WORKSPACE_URI=s3://oam-server-tiler/workspace/emr-test-job-partial-${JOB_ID}
 
 # write job configuration to S3 as REQUEST_URI
 cat <<EOF | aws s3 cp - $REQUEST_URI
@@ -26,8 +26,7 @@ cat <<EOF | aws s3 cp - $REQUEST_URI
     "jobId": "${JOB_ID}",
     "target": "s3://oam-tiles/${JOB_ID}",
     "images": [
-        "http://hotosm-oam.s3.amazonaws.com/356f564e3a0dc9d15553c17cf4583f21-12.tif",
-        "http://oin-astrodigital.s3.amazonaws.com/LC81420412015111LGN00_bands_432.TIF"
+        "s3://hotosm-oam/uploads/2016-01-05/568b113a63ebf4bc00074e67/scene/0/scene-0-image-0-Nick-Do-transparent_block_alpha_mosaic_group1.tif"
     ],
     "workspace": "${WORKSPACE_URI}"
 }

--- a/test-req-local.json
+++ b/test-req-local.json
@@ -2,8 +2,7 @@
   "jobId" : "test-job",
   "target" : "/Users/rob/proj/oam/data/results",
   "images" : [
-    "/Users/rob/proj/oam/data/raw/356f564e3a0dc9d15553c17cf4583f21-5.tif",
-    "/Users/rob/proj/oam/data/raw/LC81410412014277LGN00_bands_432.TIF"
+    "/Users/rob/proj/oam/data/upload-problem/scene-0-image-0-Nick-Do-transparent_block_alpha_mosaic_group1.tif"
   ],
   "workspace" : "/Users/rob/proj/oam/data/workspace"
 }


### PR DESCRIPTION
This PR removes some of the initial rasterio steps in `chunk.py`, because it was getting seg faults for very large images. The initial steps are now to download the image from S3 onto temporary storage, reproject to web mercator, tile it out into large chunks if the image is huge, then upload it to the workspace. The rest is basically the same.

Also, pin down the rasterio version, since they dropped support for `/vsicurl/` after 0.19 (see https://github.com/mapbox/rasterio/pull/472#issuecomment-169817208)
