### PR TITLE
Fixed issue with duplicate source URIs, bumped up version.

### DIFF
--- a/mosaic/project/Version.scala
+++ b/mosaic/project/Version.scala
@@ -1,5 +1,5 @@
 object Version {
-  val tiler       = "0.1.0"
+  val tiler       = "0.1.1"
   val scala       = "2.10.5"
   val spark       = "1.4.1"
 

--- a/mosaic/src/main/scala/org/hotosm/oam/Status.scala
+++ b/mosaic/src/main/scala/org/hotosm/oam/Status.scala
@@ -36,7 +36,7 @@ object Status {
     sendNotification(s"""{ "jobId": "$jobId", "stage": "mosaic", "status": "FAILED", "error": "$exception" }""")
 
   def notifySuccess(jobId: String, target: String, sourceUris: Seq[String]): Unit = {
-    val csv = sourceUris.map { uri => s""""$uri"""" }.mkString(",")
+    val csv = sourceUris.distinct.map { uri => s""""$uri"""" }.mkString(",")
     val sourceUrisJson = s"[$csv]"
     sendNotification(s"""{ "jobId": "$jobId", "stage": "mosaic", "status": "FINISHED", "target": "$target", "images": $sourceUrisJson }""")
   }

--- a/run-local-mosaic.sh
+++ b/run-local-mosaic.sh
@@ -3,6 +3,6 @@ time spark-submit \
     --master local[*] \
     --executor-memory 5G \
     --driver-memory 4g \
-    ./mosaic/target/scala-2.10/oam-tiler-assembly-0.1.0.jar \
+    ./mosaic/target/scala-2.10/oam-tiler-assembly-0.1.1.jar \
     /Users/rob/proj/oam/data/workspace/step1_result.json
 #    s3://workspace-oam-hotosm-org/step1_result.json

--- a/upload-code.sh
+++ b/upload-code.sh
@@ -1,5 +1,5 @@
 TARGET=s3://oam-server-tiler/emr
-VERSION=0.1.0
+VERSION=0.1.1
 
 cd mosaic && ./sbt assembly
 aws s3 cp chunk/chunk.py $TARGET/chunk-${VERSION}.py


### PR DESCRIPTION
The tiler stage was outputting duplicate images in the SQS status. This is because we initially chunk up large images when we copy the files from OIN to the HOT OSM workspace (see here: https://github.com/hotosm/oam-server-tiler/blob/master/chunk/chunk.py#L178). Each large chunk of the original image point to the original image as the source, and so the image eventually gets reported multiple times. Calling `distinct` on the source images before reporting them will fix this issue.
