### PR TITLE
Treat nodata pixels as transparent

### DIFF
--- a/chunk/chunk.py
+++ b/chunk/chunk.py
@@ -168,6 +168,7 @@ def copy_tiles_to_workspace(source_uri, order, workspace_uri):
         reprojected_path = local_path + "-reprojected.tif"
         cmd = ["gdalwarp"] + gdal_options + ["-t_srs", "EPSG:3857",
                                              "-co", "BIGTIFF=YES", # Handle giant TIFFs.
+                                             "-dstalpha",
                                              local_path,
                                              reprojected_path]
         call(cmd)

--- a/mosaic/src/main/scala/org/hotosm/oam/io/Sink.scala
+++ b/mosaic/src/main/scala/org/hotosm/oam/io/Sink.scala
@@ -12,7 +12,7 @@ trait Sink extends Function3[Int, SpatialKey, MultiBandTile, Unit] with Serializ
         val cr = if(isNoData(r)) 128 else r.toByte & 0xFF
         val cg = if(isNoData(g)) 128 else g.toByte & 0xFF
         val cb = if(isNoData(b)) 128 else b.toByte & 0xFF
-        if(cr == 0 && cg == 0 && cb == 0)
+        if(isNoData(r) && isNoData(g) && isNoData(b))
           0
         else
           (cr << 24) | (cg << 16) | (cb << 8) | 0xFF


### PR DESCRIPTION
Black pixels were previously being treated as transparent.

Multi-band images with nodata pixels on a subset of the bands will behave oddly, but they did previously too.

/cc @lossyrob 
