### PR TITLE
Create an alpha band for nodata pixels

### DIFF
--- a/chunk/chunk.py
+++ b/chunk/chunk.py
@@ -168,6 +168,7 @@ def copy_tiles_to_workspace(source_uri, order, workspace_uri):
         reprojected_path = local_path + "-reprojected.tif"
         cmd = ["gdalwarp"] + gdal_options + ["-t_srs", "EPSG:3857",
                                              "-co", "BIGTIFF=YES", # Handle giant TIFFs.
+                                             "-dstalpha",
                                              local_path,
                                              reprojected_path]
         call(cmd)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/45/18107707/f98c13c0-6ebd-11e6-9f23-9c3a13ef955d.png)

`gdalinfo` output from the working copy:

```
Band 1 Block=512x512 Type=Byte, ColorInterp=Red
  Mask Flags: PER_DATASET ALPHA
Band 2 Block=512x512 Type=Byte, ColorInterp=Green
  Mask Flags: PER_DATASET ALPHA
Band 3 Block=512x512 Type=Byte, ColorInterp=Blue
  Mask Flags: PER_DATASET ALPHA
Band 4 Block=512x512 Type=Byte, ColorInterp=Alpha
```
